### PR TITLE
Env variables in .install.sh file

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -94,6 +94,10 @@ dokmanOption "-v | --verbose" "verbose=true" "Prints out STDOUT of all commands"
 dokmanOption "-c | --colors" "forceColors=true" "Force color output"
 
 if [ -f "${DOKMAN_SCRIPT_DIR}/.install.sh" ]; then
+    cd "${DOKMAN_PROJECT_ROOT}"
+
+    loadEnvFiles "${DOKMAN_DIR}" "${DOKMAN_SCRIPT_DIR}" "${DOKMAN_ENV}"
+
     source "${DOKMAN_SCRIPT_DIR}/.install.sh"
 else
     error "File missing $(foregroundColor "${DOKMAN_SCRIPT_DIR}/.install.sh")"
@@ -176,8 +180,6 @@ function dokmanValueOption
     error "Function $(foregroundColor "dokmanValueOption" "yellow") can not be used inside $(foregroundColor "dokmanInstall" "yellow") function"
     exit 1
 }
-
-cd "${DOKMAN_PROJECT_ROOT}"
 
 # run environment event if it exists
 runEventScript "$(environmentFilePath "${DOKMAN_SCRIPT_DIR}" "${DOKMAN_ENV}")" "before-install"

--- a/src/dokman/dockerCompose.sh
+++ b/src/dokman/dockerCompose.sh
@@ -16,37 +16,10 @@ function dockerCompose
     local arguments=("${@:4}")
 
     local environmentPath
-    local projectNamePath
 
     environmentPath=$(environmentFilePath "${path}" "${env}")
-    projectNamePath=$(projectNameCacheFilePath "${dokmanDir}")
 
-    if ! hasEnv "${path}" "${env}" ; then
-        error "Environment $(foregroundColor "${env}" "yellow") is not defined in environments directory"
-        exit 1
-    fi
-
-    # import current user and group
-    importCurrentUserGroup
-
-    # import docker host IP
-    importDockerHostIP
-
-    if [ ! -f "${path}/.env.dist" ]; then
-        error "Missing main $(foregroundColor ".env.dist" "yellow") file"
-        exit 1
-    fi
-
-    # import .env.dist and .env files
-    importConfigurations "${path}"
-    # import env specific config if needed
-    importConfigurations "${environmentPath}"
-
-    handleProjectName "${projectNamePath}"
-    if ! importProjectName "${projectNamePath}" ; then
-        error "Variable $(foregroundColor "COMPOSE_PROJECT_NAME" "yellow") missing, please add at least default one"
-        exit 1
-    fi
+    loadEnvFiles "${dokmanDir}" "${path}" "${env}"
 
     local command="${arguments[0]}"
     local currentlyRunning=0

--- a/src/dokman/loadEnvFiles.sh
+++ b/src/dokman/loadEnvFiles.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+###
+ # Load dokman specific env files
+ #
+ # @param1 string Dokman dir
+ # @param2 string Path to docker directory
+ # @param3 string Environment file name to load
+###
+function loadEnvFiles
+{
+    local dokmanDir=${1}
+    local path=${2}
+    local env=${3}
+
+    local environmentPath
+    local projectNamePath
+
+    environmentPath=$(environmentFilePath "${path}" "${env}")
+    projectNamePath=$(projectNameCacheFilePath "${dokmanDir}")
+
+    if ! hasEnv "${path}" "${env}" ; then
+        error "Environment $(foregroundColor "${env}" "yellow") is not defined in environments directory"
+        exit 1
+    fi
+
+    # import current user and group
+    importCurrentUserGroup
+
+    # import docker host IP
+    importDockerHostIP
+
+    if [ ! -f "${path}/.env.dist" ]; then
+        error "Missing main $(foregroundColor ".env.dist" "yellow") file"
+        exit 1
+    fi
+
+    # import .env.dist and .env files
+    importConfigurations "${path}"
+    # import env specific config if needed
+    importConfigurations "${environmentPath}"
+
+    handleProjectName "${projectNamePath}"
+    if ! importProjectName "${projectNamePath}" ; then
+        error "Variable $(foregroundColor "COMPOSE_PROJECT_NAME" "yellow") missing, please add at least default one"
+        exit 1
+    fi
+}


### PR DESCRIPTION
All environment variables defined in .env and .env.dist, no
matter docker root or environment folder where not loaded
in installation script. Now those environment variables are
available.

Should fix #15